### PR TITLE
Snippet service fix

### DIFF
--- a/client/src/Components/Game/Game.js
+++ b/client/src/Components/Game/Game.js
@@ -9,6 +9,8 @@ import Timer from "../Timer/Timer";
 const Game = ({defaultSnippet}) => {
     // what the user has typed so far for the current word
 	// cleared with wordIndex changes
+	const [currSnippet, setCurrSnippet] = useState({});
+
 	const [lines, setLines] = useState(defaultSnippet);
 
 	const [userInput, setUserInput] = useState('');
@@ -46,9 +48,9 @@ const Game = ({defaultSnippet}) => {
 
 	const snapshot = useRef(['']);
 
-	const [selectedLength, setSelectedLength] = useState(1);
+	const [selectedLength, setSelectedLength] = useState();
 
-  const [selectedType, setSelectedType] = useState('snippet type');
+  const [selectedType, setSelectedType] = useState();
 
 	useEffect(() => {
 		currLine.current = lines[0].split(" ")
@@ -117,6 +119,8 @@ const Game = ({defaultSnippet}) => {
 				setSelectedLength={setSelectedLength}
 				selectedType={selectedType}
 				setSelectedType={setSelectedType}
+				currSnippet={currSnippet} 
+				setCurrSnippet={setCurrSnippet}
 			/>
 		</div>
     ) :
@@ -131,6 +135,8 @@ const Game = ({defaultSnippet}) => {
 					setSelectedLength={setSelectedLength}
 					selectedType={selectedType}
 					setSelectedType={setSelectedType}
+					currSnippet={currSnippet} 
+					setCurrSnippet={setCurrSnippet}
 				/>
 			</div>
 		);

--- a/client/src/Components/GameOptions/GameOptions.js
+++ b/client/src/Components/GameOptions/GameOptions.js
@@ -13,7 +13,7 @@ import Navbar from 'react-bootstrap/Navbar';
 import Button from 'react-bootstrap/Button';
 import next from './nextArrow';
 import "./GameOptions.css"
-
+import { useState } from 'react';
 import "bootstrap/dist/css/bootstrap-grid.min.css";
 
 const GameOptions = (props) => {
@@ -23,17 +23,28 @@ const GameOptions = (props) => {
 		selectedType, 
 		setSelectedType, 
 		selectedLength, 
-		setSelectedLength 
+		setSelectedLength, 
+		currSnippet, 
+		setCurrSnippet
 	} = props;
 
+	const [currSnippets, setCurrSnippets] = useState([]);
+	
 	
 	const onNewSnippetClick = () => {
+		// console.log('currSnippet', currSnippet)
+		// console.log('currSnippets', currSnippets)
+		// console.log('selLen', selectedLength)
+		// console.log('selType', selectedType)
+		if (!selectedLength || !selectedType) return;
+		let nextIndex = currSnippets.findIndex(snippet => currSnippet.id === snippet.id)
+		nextIndex = (nextIndex + 1) % currSnippets.length;
+		console.log('nextIndex', nextIndex);
+		console.log('next snippet', currSnippets[nextIndex])
 
-		getSnippet(selectedLength, selectedType)
-			.then(snippet => {
-				setLines(snippet);
-				restartGame();
-			})
+		setCurrSnippet(currSnippets[nextIndex]);
+		setLines(currSnippets[nextIndex].data);
+		restartGame();
 	}
 
 	return(
@@ -46,6 +57,8 @@ const GameOptions = (props) => {
 						setSelectedType={setSelectedType} 
 						selectedLength={selectedLength} 
 						setSelectedLength={setSelectedLength}
+						currSnippet={currSnippet} 
+						setCurrSnippets={setCurrSnippets}
 					/>
 				</Col>
 				<Col xs sm='auto' md={{offset: 2}}>

--- a/client/src/Components/SnippetOptions/SnippetOptions.js
+++ b/client/src/Components/SnippetOptions/SnippetOptions.js
@@ -1,21 +1,54 @@
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
 import ToggleButton from 'react-bootstrap/ToggleButton';
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Dropdown from 'react-bootstrap/Dropdown';
 import DropdownButton from 'react-bootstrap/DropdownButton';
+import getSnippet  from '../../services/snippetService';
 import style from "./SnippetOptions.css"
 import 'bootstrap/dist/css/bootstrap.css';
 
-const SnippetOptions = ({ selectedType, setSelectedType, selectedLength, setSelectedLength }) => {
-  
+const SnippetOptions = (props) => {
+  const { 
+    selectedType,
+    setSelectedType,
+    selectedLength,
+    setSelectedLength, 
+    setCurrSnippets
+  } = props;
+
+  useEffect(() => {
+    console.log('in useEffect')
+    if (selectedLength && selectedType) {
+      console.log('in if statement')
+      loadNewSnippets(selectedLength, selectedType)
+    }
+  }
+  , [selectedLength, selectedType]) 
+
+  const loadNewSnippets = (len, type) => {
+    console.log('len', len)
+    console.log(selectedLength)
+    console.log('type', type)
+    console.log(selectedType)
+    
+    getSnippet(len, type)
+			.then(snippets => {
+				setCurrSnippets(snippets);
+        console.log(snippets)
+			})
+  }
 
   const handleLengthChange = (value) => {
+    if (value === selectedLength) return;
     setSelectedLength(value);
+    //loadNewSnippets(selectedLength, selectedType);
   }
 
   const handleTypeChange = (value) => {
+    if (value === selectedType) return;
     setSelectedType(value);
+    //loadNewSnippets(selectedLength, selectedType);
   }
 
   const displayedType = (() => {

--- a/client/src/Components/SnippetOptions/SnippetOptions.js
+++ b/client/src/Components/SnippetOptions/SnippetOptions.js
@@ -59,8 +59,8 @@ const SnippetOptions = (props) => {
         return 'for loop';
       case 'WHILE':
         return 'while loop';
-      case 'CONDITIONAL':
-        return 'conditional'
+      case 'COLLECTIONS':
+        return 'collections'
       default:
         return 'snippet type';
     }
@@ -81,7 +81,7 @@ const SnippetOptions = (props) => {
               <Dropdown.Item eventKey="METHOD">methods</Dropdown.Item>
               <Dropdown.Item eventKey="FOR">for loop</Dropdown.Item>
               <Dropdown.Item eventKey="WHILE">while loop</Dropdown.Item>
-              <Dropdown.Item eventKey="CONDITIONAL">conditional</Dropdown.Item>
+              <Dropdown.Item eventKey="COLLECTIONS">collections</Dropdown.Item>
             </DropdownButton>
           </Dropdown>
           <ToggleButtonGroup 

--- a/client/src/Components/TextArea/TextArea.js
+++ b/client/src/Components/TextArea/TextArea.js
@@ -218,7 +218,7 @@ export default function TextArea(props) {
 		}
 	}
 
-	DEBUG(currWordHasMistake(currWord, userInput), allowedToOverflow(currWord, userInput));
+	//DEBUG(currWordHasMistake(currWord, userInput), allowedToOverflow(currWord, userInput));
 
 	const renderedLines = lines.map((line, index) => {
 		return (

--- a/client/src/services/snippetService.js
+++ b/client/src/services/snippetService.js
@@ -1,9 +1,10 @@
-import axios from 'axios'
+import axios from 'axios';
+//const axios = require('axios');
 
 const baseURL = 'http://localhost:3001'
 
 const errSnippet =  {
-    id: 1,
+    id: -1,
     SnippetType:'ERROR',
     length: 'NA',
     data: [
@@ -13,20 +14,14 @@ const errSnippet =  {
     ]
 }
 
-export default function getSnippet(len, type) {
-    let previousIndex = -1; // initialize the previous index to an invalid value
+const getSnippet = (len, type) => {
     const req = axios.get(`${baseURL}/api/read/get/lengthandtype?length=${len}&type=${type}`);
     return req.then(res => {
-        if (res.status === 200 && res.data.length !== 0) {
-            let index = Math.floor(Math.random() * res.data.length);
-            // generate a new index if it's the same as the previous index
-            while (index === previousIndex) {
-                index = Math.floor(Math.random() * res.data.length);
-            }
-            previousIndex = index; // update the previous index
-            return res.data[index].data;
-        } else return errSnippet.data;
+        return (res.status === 200 && res.data.length !== 0) ? res.data : [errSnippet];
     });
 }
+
+export default getSnippet;
+//module.exports = {getSnippet};
 
 

--- a/client/src/services/test.js
+++ b/client/src/services/test.js
@@ -1,0 +1,3 @@
+const { getSnippet } = require("./snippetService");
+
+getSnippet("LONG", "WHILE").then(res => console.log(res));

--- a/server/requests/getSnippetByLengthAndType.rest
+++ b/server/requests/getSnippetByLengthAndType.rest
@@ -1,1 +1,1 @@
-GET http://localhost:3001/api/read/get/lengthandtype?length=LONG&type=WHILE_LOOP
+GET http://localhost:3001/api/read/get/lengthandtype?length=LONG&type=WHILE

--- a/server/requests/getSnippetByType.rest
+++ b/server/requests/getSnippetByType.rest
@@ -1,1 +1,1 @@
-GET http://localhost:3001/api/read/get/type?type=FOR_LOOP
+GET http://localhost:3001/api/read/get/type?type=COLLECTIONS


### PR DESCRIPTION
Fixed issue with API latency on client side by pre-loading all snippets matching the current selection. If we eventually have enough snippets it will make sense to limit the number of pre-loaded snippets, but for now this isn't required.