### PR TITLE
styled login page, fixed navbar width, edited colors (leaderboard & buttons)

### DIFF
--- a/client/src/Components/Leaderboard/Leaderboard.css
+++ b/client/src/Components/Leaderboard/Leaderboard.css
@@ -1,5 +1,6 @@
 .leaderboard-container {
-    background: linear-gradient(to bottom, #f9f9f9, #fcdfdf);
+    /* background: linear-gradient(to bottom, #f9f9f9, #fcdfdf); */
+    background: #fcdfdf;
     border-radius: 15px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
     margin: 20px auto;
@@ -21,9 +22,11 @@
   }
   
   .leaderboard-table th {
-    background-color: #f7bfbf;
+    /* background-color: #f7bfbf; */
+    background-color: rgb(239, 177, 177);
     padding: 10px;
-    color: #999696;
+    /* color: #999696; */
+    color: rgba(125, 97, 95, 1);
     font-size: 100%;
     font-weight: 500;
     text-transform: uppercase;
@@ -34,7 +37,8 @@
   }
   
   .leaderboard-table tr:nth-child(even) td {
-    background-color: #f7bfbf;
+    /* background-color: #f7bfbf; */
+    background-color: rgb(239, 177, 177);
   }
   
   .leaderboard-table td:first-child {

--- a/client/src/Components/Login/Login.css
+++ b/client/src/Components/Login/Login.css
@@ -1,0 +1,41 @@
+.login-container {
+    background: #fcdfdf;
+    border-radius: 8px;
+    margin: 80px auto;
+    max-width: 400px;
+    padding: 20px;
+}
+
+.input-container {
+    display: flex;
+    justify-content: center;
+    padding-bottom: 3.5%;
+}
+
+.input-textbox {
+    border-radius: 8px;
+    border-color: #fcdfdf;
+    background-color: #BC8785;
+    padding-left: 10px;
+    color: #fff;
+    width: 100%;
+    height: 40px;    
+}
+
+.button-container {
+  display: flex;
+  justify-content: right;
+  padding-top: 5px;
+}
+
+.submit-button {
+    background: #ebc6c6;
+    border-color: transparent;
+    color: #7D615F;
+    justify-content: right;
+    border-radius: 5px;
+}
+
+.input-textbox::placeholder {
+  color: #fff9;
+}

--- a/client/src/Components/Login/Login.js
+++ b/client/src/Components/Login/Login.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { authenticate, getCurrentUser } from '../../services/userService'
+import './Login.css'
 
 const Login = () => {
   const [username, setUsername] = useState('')
@@ -23,33 +24,42 @@ const Login = () => {
   }
 
   return (
-    <>
-      <h2> Login to an existing account</h2>
+    <div className="login-container" style={{margin: "auto"}}>
+      <h2 style={{fontSize: "2em", color: "#7D615F"}}>log in</h2>
+      <p style={{fontSize: "1em", color: "#7D615F", textAlign: 'right'}}>forgot password?</p>
       <form onSubmit={handleLogin}>
-        <div>
-          <label>Username:</label>
+        <div className="input-container">
           <input
+            className="input-textbox"
             type='text'
             id='username'
+            placeholder='username'
             value={username}
             onChange={handleUsernameChange}
           />
         </div>
-        <div>
-          <label>Password:</label>
+        <div className="input-container">
           <input
+            className="input-textbox"
             type='password'
             id='password'
+            placeholder='password'
             value={password}
             onChange={handlePasswordChange}
           />
         </div>
-        <button type='submit' onClick={handleLogin}>
-          Login
-        </button>
-        {errorMessage && <span style={{ color: 'red' }}>{errorMessage}</span>}
+        <div className='button-container'>
+          <button className="submit-button" type='submit' onClick={handleLogin}>
+            login
+          </button>
+        </div>
+        <div style={{ textAlign: 'center', paddingTop: '12px' }}>
+          {errorMessage && <span 
+              style={{ whiteSpace: "pre-line", 
+                       color: 'red' }}>{errorMessage}</span>}
+        </div>
       </form>
-    </>
+    </div>
   )
 }
 

--- a/client/src/Components/NavBar/NavBar.css
+++ b/client/src/Components/NavBar/NavBar.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    max-width: 1000px;
+    max-width: 92%;
     margin: 0 auto;
   }
   
@@ -10,6 +10,7 @@
     color: rgba(125, 97, 95, 1);
     font-size: 2.5em;
     text-decoration: none;
+    margin: 0;
   }
   
   .button-container {
@@ -18,7 +19,8 @@
   }
   
   .button-container a {
-    color: rgb(255, 232, 230);
+    /* color: rgb(255, 232, 230); */
+    color: #fff;
     background-color: rgb(219, 157, 157);
     text-decoration: none;
     margin-left: .5em;
@@ -29,7 +31,8 @@
   }
   
   .button-container a:hover {
-    background-color: rgb(255, 213, 213);
+    /* background-color: rgb(255, 213, 213); */
     color: #fff;
+    background-color: rgb(188, 127, 127);
   }
   

--- a/client/src/Components/NavBar/NavBar.js
+++ b/client/src/Components/NavBar/NavBar.js
@@ -13,6 +13,7 @@ const NavBar = ({ setSettingsFocus }) => {
           <Link to='/leaderboard'>leaderboard</Link>
           <Link to='/'>game</Link>
           <Link to='/account'>account</Link>
+          <Link to='/login'>login</Link>
           <Icon setSettingsFocus={setSettingsFocus} />
         </div>
       </div>


### PR DESCRIPTION
added a button on the top-bar navigating to the login page. styled the login page to look like the figma, including styling for textbox placeholders and potential error messages.
fixed the navbar width to 95%, and edited color schemes for top-bar button hovering and the leaderboard.